### PR TITLE
fix: refactor the service to get head branch

### DIFF
--- a/bin/utils/flow.js
+++ b/bin/utils/flow.js
@@ -73,12 +73,13 @@ module.exports = {
      */
     fetchHeadBranch: async function (owner, repo) {
         spinner.start('Fetching head branch...');
-        const {data: branches} = await octokit.request('GET /repos/{owner}/{repo}/branches', {
+        const {data: headBranch} = await octokit.request('GET /repos/{owner}/{repo}/branches/{branch}', {
             owner: owner,
-            repo: repo
+            repo: repo,
+            branch: 'master'
         });
-        const headBranch = helper.retrieveHeadBranch(branches);
-        spinner.succeed(`Head branch is fetched: ${kleur.blue().bold().underline(headBranch)}`);
+
+        spinner.succeed(`Head branch is fetched: ${kleur.blue().bold().underline(headBranch.name)}`);
         return headBranch;
     },
 

--- a/bin/utils/helper.js
+++ b/bin/utils/helper.js
@@ -123,18 +123,6 @@ module.exports = {
     },
 
     /**
-     *
-     * retrieves the head branch from the given {@code branch} list.
-     *
-     * @param branches the all the branches which are belongs to the related repository.
-     * @returns {null|*}
-     */
-    retrieveHeadBranch: function (branches) {
-        let headBranch = branches.find(branch => branch.name === 'master' || branch.name === 'main');
-        return headBranch == undefined ? null : headBranch.name;
-    },
-
-    /**
      * checks if all the required environment variables are set.
      *
      * @returns {boolean}


### PR DESCRIPTION
Previous approach was retrieving all the branches in the repo and was trying to find `master` or `main` branch in the result set. The default resultset contains at most `100` items and if the repo has contains more than `100` the function was not able to find the head branch. 