### PR TITLE
fix: exclude self-referential check run when verifying status checks in GitHub Actions

### DIFF
--- a/bin/services/status-check-service.js
+++ b/bin/services/status-check-service.js
@@ -35,6 +35,10 @@ export async function verifyStatusChecks(owner, repo, ref, skip, {
         return;
     }
 
+    // When running inside GitHub Actions, GITHUB_JOB is the current job's key.
+    // Exclude it to prevent a release job from blocking itself on its own check run.
+    const selfCheckRunName = process.env.GITHUB_ACTIONS === 'true' ? process.env.GITHUB_JOB : null;
+
     spinner.start(`Verifying status checks on '${ref}'...`);
 
     const [commitStatus, checkRuns] = await Promise.all([
@@ -42,7 +46,7 @@ export async function verifyStatusChecks(owner, repo, ref, skip, {
         fetchCheckRuns(owner, repo, ref)
     ]);
 
-    const pendingRun = checkRuns.find(run => PENDING_CHECK_RUN_STATUSES.has(run.status));
+    const pendingRun = checkRuns.find(run => PENDING_CHECK_RUN_STATUSES.has(run.status) && run.name !== selfCheckRunName);
     if (pendingRun) {
         spinner.fail(`Status checks are still running on '${ref}'.`);
         throw createError(
@@ -52,7 +56,7 @@ export async function verifyStatusChecks(owner, repo, ref, skip, {
         );
     }
 
-    const failedRun = checkRuns.find(run => FAILED_CHECK_RUN_CONCLUSIONS.has(run.conclusion));
+    const failedRun = checkRuns.find(run => FAILED_CHECK_RUN_CONCLUSIONS.has(run.conclusion) && run.name !== selfCheckRunName);
     if (failedRun) {
         spinner.fail(`Status checks have failed on '${ref}'.`);
         throw createError(

--- a/bin/services/status-check-service.js
+++ b/bin/services/status-check-service.js
@@ -46,7 +46,10 @@ export async function verifyStatusChecks(owner, repo, ref, skip, {
         fetchCheckRuns(owner, repo, ref)
     ]);
 
-    const pendingRun = checkRuns.find(run => PENDING_CHECK_RUN_STATUSES.has(run.status) && run.name !== selfCheckRunName);
+    const pendingRun = checkRuns.find(run =>
+        PENDING_CHECK_RUN_STATUSES.has(run.status) &&
+        !(run.status === 'in_progress' && run.name === selfCheckRunName)
+    );
     if (pendingRun) {
         spinner.fail(`Status checks are still running on '${ref}'.`);
         throw createError(
@@ -56,7 +59,7 @@ export async function verifyStatusChecks(owner, repo, ref, skip, {
         );
     }
 
-    const failedRun = checkRuns.find(run => FAILED_CHECK_RUN_CONCLUSIONS.has(run.conclusion) && run.name !== selfCheckRunName);
+    const failedRun = checkRuns.find(run => FAILED_CHECK_RUN_CONCLUSIONS.has(run.conclusion));
     if (failedRun) {
         spinner.fail(`Status checks have failed on '${ref}'.`);
         throw createError(

--- a/test/status-check-service.test.js
+++ b/test/status-check-service.test.js
@@ -175,7 +175,7 @@ test("verifyStatusChecks prioritises check run failure over legacy status", asyn
     );
 });
 
-test("verifyStatusChecks skips own check run when running inside GitHub Actions", async () => {
+test("verifyStatusChecks skips own in_progress check run when running inside GitHub Actions", async () => {
     process.env.GITHUB_ACTIONS = 'true';
     process.env.GITHUB_JOB = 'release';
     try {
@@ -204,6 +204,48 @@ test("verifyStatusChecks still blocks on other in_progress check runs when runni
             error => {
                 assert.match(error.message, /ci/);
                 assert.match(error.message, /in_progress/);
+                return true;
+            }
+        );
+    } finally {
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.GITHUB_JOB;
+    }
+});
+
+test("verifyStatusChecks does not skip own check run when it is queued", async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.GITHUB_JOB = 'release';
+    try {
+        await assert.rejects(
+            () => verifyStatusChecks("owner", "repo", "abc123", false, {
+                fetchStatus: async () => noChecks,
+                fetchCheckRuns: async () => [makeRun("release", "queued")]
+            }),
+            error => {
+                assert.match(error.message, /release/);
+                assert.match(error.message, /queued/);
+                return true;
+            }
+        );
+    } finally {
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.GITHUB_JOB;
+    }
+});
+
+test("verifyStatusChecks does not skip own check run when it has a failed conclusion", async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.GITHUB_JOB = 'release';
+    try {
+        await assert.rejects(
+            () => verifyStatusChecks("owner", "repo", "abc123", false, {
+                fetchStatus: async () => noChecks,
+                fetchCheckRuns: async () => [makeRun("release", "completed", "failure")]
+            }),
+            error => {
+                assert.match(error.message, /release/);
+                assert.match(error.message, /failure/);
                 return true;
             }
         );

--- a/test/status-check-service.test.js
+++ b/test/status-check-service.test.js
@@ -174,3 +174,57 @@ test("verifyStatusChecks prioritises check run failure over legacy status", asyn
         }
     );
 });
+
+test("verifyStatusChecks skips own check run when running inside GitHub Actions", async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.GITHUB_JOB = 'release';
+    try {
+        await assert.doesNotReject(() => verifyStatusChecks("owner", "repo", "abc123", false, {
+            fetchStatus: async () => noChecks,
+            fetchCheckRuns: async () => [makeRun("release", "in_progress")]
+        }));
+    } finally {
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.GITHUB_JOB;
+    }
+});
+
+test("verifyStatusChecks still blocks on other in_progress check runs when running inside GitHub Actions", async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.GITHUB_JOB = 'release';
+    try {
+        await assert.rejects(
+            () => verifyStatusChecks("owner", "repo", "abc123", false, {
+                fetchStatus: async () => noChecks,
+                fetchCheckRuns: async () => [
+                    makeRun("release", "in_progress"),
+                    makeRun("ci", "in_progress")
+                ]
+            }),
+            error => {
+                assert.match(error.message, /ci/);
+                assert.match(error.message, /in_progress/);
+                return true;
+            }
+        );
+    } finally {
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.GITHUB_JOB;
+    }
+});
+
+test("verifyStatusChecks does not skip own check run name when not running inside GitHub Actions", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
+    await assert.rejects(
+        () => verifyStatusChecks("owner", "repo", "abc123", false, {
+            fetchStatus: async () => noChecks,
+            fetchCheckRuns: async () => [makeRun("release", "in_progress")]
+        }),
+        error => {
+            assert.match(error.message, /release/);
+            assert.match(error.message, /in_progress/);
+            return true;
+        }
+    );
+});


### PR DESCRIPTION
## Problem

When `yaba release create` runs inside a GitHub Actions workflow job, GitHub registers that job as an `in_progress` check run on the target commit. If the release target resolves to the same commit the workflow is running against (e.g. HEAD of the default branch, no `--target` flag provided), `verifyStatusChecks` queries the GitHub Check Runs API and finds its own job still `in_progress` — blocking itself from completing.

**Example error:**
> ✖ Status checks are still running on 'master'. Cannot release: check run 'release' is still in_progress on 'master'.

## Root cause

`GITHUB_JOB` contains the current job's key (e.g. `release`, `prepare-release`). GitHub names the check run after this key when no `name:` field is set on the job. `verifyStatusChecks` had no awareness of which check run belonged to the currently running job.

## Fix

Read `GITHUB_ACTIONS` and `GITHUB_JOB` from the environment inside `verifyStatusChecks`. When both are set, exclude the matching check run from the pending/failed detection. Outside GitHub Actions, both variables are absent, so behavior is unchanged.

**Note:** This works when the job has no custom `name:` field. If a job defines `name: Display Name`, `GITHUB_JOB` holds the key while GitHub names the check run after the display name — they won't match. The existing `--no-status-checks` flag remains the escape hatch for that case.