### PR TITLE
fix: exclude self check run from status verification regardless of status

### DIFF
--- a/bin/services/status-check-service.js
+++ b/bin/services/status-check-service.js
@@ -48,7 +48,7 @@ export async function verifyStatusChecks(owner, repo, ref, skip, {
 
     const pendingRun = checkRuns.find(run =>
         PENDING_CHECK_RUN_STATUSES.has(run.status) &&
-        !(run.status === 'in_progress' && run.name === selfCheckRunName)
+        !(run.name === selfCheckRunName)
     );
     if (pendingRun) {
         spinner.fail(`Status checks are still running on '${ref}'.`);

--- a/test/status-check-service.test.js
+++ b/test/status-check-service.test.js
@@ -21,6 +21,8 @@ test("verifyStatusChecks returns immediately when skip is true", async () => {
 });
 
 test("verifyStatusChecks passes when all check runs are completed with success", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.doesNotReject(() => verifyStatusChecks("owner", "repo", "abc123", false, {
         fetchStatus: async () => successStatus,
         fetchCheckRuns: async () => [
@@ -31,6 +33,8 @@ test("verifyStatusChecks passes when all check runs are completed with success",
 });
 
 test("verifyStatusChecks passes when check runs are completed with neutral or skipped conclusions", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.doesNotReject(() => verifyStatusChecks("owner", "repo", "abc123", false, {
         fetchStatus: async () => noChecks,
         fetchCheckRuns: async () => [
@@ -41,6 +45,8 @@ test("verifyStatusChecks passes when check runs are completed with neutral or sk
 });
 
 test("verifyStatusChecks passes when there are no check runs and no legacy status checks", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.doesNotReject(() => verifyStatusChecks("owner", "repo", "abc123", false, {
         fetchStatus: async () => noChecks,
         fetchCheckRuns: async () => []
@@ -48,6 +54,8 @@ test("verifyStatusChecks passes when there are no check runs and no legacy statu
 });
 
 test("verifyStatusChecks throws when a check run is queued", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => noChecks,
@@ -64,6 +72,8 @@ test("verifyStatusChecks throws when a check run is queued", async () => {
 });
 
 test("verifyStatusChecks throws when a check run is in_progress", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => noChecks,
@@ -79,6 +89,8 @@ test("verifyStatusChecks throws when a check run is in_progress", async () => {
 });
 
 test("verifyStatusChecks throws when a check run has conclusion failure", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => noChecks,
@@ -95,6 +107,8 @@ test("verifyStatusChecks throws when a check run has conclusion failure", async 
 });
 
 test("verifyStatusChecks throws when a check run has conclusion timed_out", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => noChecks,
@@ -110,6 +124,8 @@ test("verifyStatusChecks throws when a check run has conclusion timed_out", asyn
 });
 
 test("verifyStatusChecks throws when a check run has conclusion action_required", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => noChecks,
@@ -125,6 +141,8 @@ test("verifyStatusChecks throws when a check run has conclusion action_required"
 });
 
 test("verifyStatusChecks throws on legacy pending status when totalCount is non-zero", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => pendingStatus,
@@ -140,6 +158,8 @@ test("verifyStatusChecks throws on legacy pending status when totalCount is non-
 });
 
 test("verifyStatusChecks throws on legacy failure status when totalCount is non-zero", async () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_JOB;
     await assert.rejects(
         () => verifyStatusChecks("owner", "repo", "abc123", false, {
             fetchStatus: async () => failureStatus,

--- a/test/status-check-service.test.js
+++ b/test/status-check-service.test.js
@@ -213,17 +213,34 @@ test("verifyStatusChecks still blocks on other in_progress check runs when runni
     }
 });
 
-test("verifyStatusChecks does not skip own check run when it is queued", async () => {
+test("verifyStatusChecks skips own queued check run when running inside GitHub Actions", async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.GITHUB_JOB = 'release';
+    try {
+        await assert.doesNotReject(() => verifyStatusChecks("owner", "repo", "abc123", false, {
+            fetchStatus: async () => noChecks,
+            fetchCheckRuns: async () => [makeRun("release", "queued")]
+        }));
+    } finally {
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.GITHUB_JOB;
+    }
+});
+
+test("verifyStatusChecks still blocks on other queued check runs when running inside GitHub Actions", async () => {
     process.env.GITHUB_ACTIONS = 'true';
     process.env.GITHUB_JOB = 'release';
     try {
         await assert.rejects(
             () => verifyStatusChecks("owner", "repo", "abc123", false, {
                 fetchStatus: async () => noChecks,
-                fetchCheckRuns: async () => [makeRun("release", "queued")]
+                fetchCheckRuns: async () => [
+                    makeRun("release", "queued"),
+                    makeRun("ci", "queued")
+                ]
             }),
             error => {
-                assert.match(error.message, /release/);
+                assert.match(error.message, /ci/);
                 assert.match(error.message, /queued/);
                 return true;
             }


### PR DESCRIPTION
## Summary

Fixes the bug where releasing fails with 'check status is pending' error even when the only pending check is the release job itself.

## Problem

When triggering a release via GitHub Actions workflow dispatch, the `verifyStatusChecks` function checks that all status checks on the target commit have completed. It attempts to exclude the job's own check run from this validation to avoid self-blocking, but only when the status is `'in_progress'`.

However, when a workflow first starts, the check run status is `'queued'`, not `'in_progress'` yet. This causes releases to fail with the error:
```
Cannot release: commit status is 'pending' on '<commit>'. 
Wait for all checks to complete before releasing, or use --no-status-checks to bypass this gate.
```

## Solution

Fixed the self-check-run exclusion logic in `bin/services/status-check-service.js` to exclude the self check run for all pending statuses (`'queued'` and `'in_progress'`), not just `'in_progress'`.

## Changes

- **bin/services/status-check-service.js:51** — Updated exclusion condition from `!(run.status === 'in_progress' && run.name === selfCheckRunName)` to `!(run.name === selfCheckRunName)` to handle all pending statuses
- **test/status-check-service.test.js** — Updated test expectations and added test case for queued status exclusion

## Testing

All 19 status check tests pass:
- ✅ Self check run is now skipped when queued
- ✅ Other queued checks are still properly blocked  
- ✅ All existing test cases continue to pass