### PR TITLE
fix: prevent Slack 400 errors for large release notes

### DIFF
--- a/bin/utils/helper.js
+++ b/bin/utils/helper.js
@@ -159,13 +159,82 @@ export function prepareSlackMessage(repo, message, releaseUrl, releaseName, comp
     const templateFile = fs.readFileSync(slackMessageTemplatePath, 'utf8');
     const templateJson = JSON.parse(templateFile);
 
-    return applyTemplateValues(templateJson, {
+    const payload = applyTemplateValues(templateJson, {
         repo: repo,
         newsletterBody: message.trim(),
         releaseUrl: releaseUrl,
         releaseName: releaseName,
         compareUrl: compareUrl || releaseUrl
     });
+
+    payload.blocks = payload.blocks.flatMap(block => {
+        if (block.type === 'header' && block.text?.text) {
+            return [{
+                ...block,
+                text: {
+                    ...block.text,
+                    text: truncateText(block.text.text, 150)
+                }
+            }];
+        }
+
+        if (block.type !== 'section' || block.text?.text !== message.trim()) {
+            return [block];
+        }
+
+        return splitText(message.trim(), 3000).map(text => ({
+            ...block,
+            text: {
+                ...block.text,
+                text: text
+            }
+        }));
+    });
+
+    return payload;
+}
+
+function splitText(value, maxLength) {
+    const chunks = [];
+    let current = '';
+
+    for (const line of value.split('\n')) {
+        const candidate = current ? `${current}\n${line}` : line;
+        if (textLength(candidate) <= maxLength) {
+            current = candidate;
+            continue;
+        }
+
+        if (current) {
+            chunks.push(current);
+            current = '';
+        }
+
+        const characters = Array.from(line);
+        while (characters.length > maxLength) {
+            chunks.push(characters.splice(0, maxLength).join(''));
+        }
+        current = characters.join('');
+    }
+
+    if (current || chunks.length === 0) {
+        chunks.push(current);
+    }
+
+    return chunks;
+}
+
+function truncateText(value, maxLength) {
+    const characters = Array.from(value);
+    if (characters.length <= maxLength) {
+        return value;
+    }
+
+    return `${characters.slice(0, maxLength - 1).join('')}…`;
+}
+
+function textLength(value) {
+    return Array.from(value).length;
 }
 
 

--- a/bin/utils/slack.js
+++ b/bin/utils/slack.js
@@ -44,7 +44,12 @@ export async function publish(publish, repo, changelog, releaseUrl, releaseName,
             spinner.succeed('Changelog published to Slack.');
         } catch (error) {
             spinner.fail('Release was created but Slack announcement failed.');
-            throw createError('Release was created but Slack announcement failed.', exitCodes.PARTIAL_SUCCESS, error);
+            const detail = describeSlackFailure(error);
+            throw createError(
+                `Release was created but Slack announcement failed.${detail ? ` ${detail}` : ''}`,
+                exitCodes.PARTIAL_SUCCESS,
+                error
+            );
         }
     }
 }
@@ -94,6 +99,21 @@ function isRetriable(error) {
     }
 
     return status === 429 || status === 408 || (typeof status === 'number' && status >= 500);
+}
+
+function describeSlackFailure(error) {
+    const status = error?.response?.status || error?.status;
+    const responseData = error?.response?.data;
+    const responseText = typeof responseData === 'string'
+        ? responseData.trim()
+        : responseData?.error;
+
+    if (!status && !responseText) {
+        return '';
+    }
+
+    const statusText = status ? `HTTP ${status}` : 'Slack error';
+    return responseText ? `${statusText}: ${responseText}.` : `${statusText}.`;
 }
 
 function resolveMaxAttempts(value) {

--- a/test/slack-message-template.test.js
+++ b/test/slack-message-template.test.js
@@ -39,3 +39,77 @@ test("prepareSlackMessage falls back compare link to release URL when compare UR
     assert.match(linkContext.elements[0].text, /Release Notes/);
     assert.match(linkContext.elements[0].text, new RegExp(escapeRegExp(releaseUrl)));
 });
+
+test("prepareSlackMessage keeps a 3000-character newsletter in one section", () => {
+    const payload = prepareSlackMessage(
+        "yaba",
+        "x".repeat(3000),
+        "https://example.com/release",
+        "Release v2.1.0",
+        "https://example.com/compare"
+    );
+
+    const sections = payload.blocks.filter(item => item.type === "section");
+    assert.equal(sections.length, 1);
+    assert.equal(Array.from(sections[0].text.text).length, 3000);
+});
+
+test("prepareSlackMessage splits newsletters over 3000 characters on line boundaries", () => {
+    const firstLine = "x".repeat(2995);
+    const payload = prepareSlackMessage(
+        "yaba",
+        `${firstLine}\nsecond line`,
+        "https://example.com/release",
+        "Release v2.1.0",
+        "https://example.com/compare"
+    );
+
+    const sections = payload.blocks.filter(item => item.type === "section");
+    assert.equal(sections.length, 2);
+    assert.equal(sections[0].text.text, firstLine);
+    assert.equal(sections[1].text.text, "second line");
+    assert.ok(sections.every(item => Array.from(item.text.text).length <= 3000));
+});
+
+test("prepareSlackMessage splits an individual line over 3000 characters", () => {
+    const payload = prepareSlackMessage(
+        "yaba",
+        "🚀".repeat(3001),
+        "https://example.com/release",
+        "Release v2.1.0",
+        "https://example.com/compare"
+    );
+
+    const sections = payload.blocks.filter(item => item.type === "section");
+    assert.deepEqual(
+        sections.map(item => Array.from(item.text.text).length),
+        [3000, 1]
+    );
+});
+
+test("prepareSlackMessage truncates headers to Slack's 150-character limit", () => {
+    const payload = prepareSlackMessage(
+        "repository",
+        "Release notes",
+        "https://example.com/release",
+        "🚀".repeat(160),
+        "https://example.com/compare"
+    );
+
+    const header = payload.blocks.find(item => item.type === "header");
+    assert.equal(Array.from(header.text.text).length, 150);
+    assert.match(header.text.text, /…$/);
+});
+
+test("prepareSlackMessage does not add an ellipsis to headers within Slack's limit", () => {
+    const payload = prepareSlackMessage(
+        "yaba",
+        "Release notes",
+        "https://example.com/release",
+        "Release v2.1.0",
+        "https://example.com/compare"
+    );
+
+    const header = payload.blocks.find(item => item.type === "header");
+    assert.doesNotMatch(header.text.text, /…$/);
+});


### PR DESCRIPTION
## Summary

- split Slack release-note content across multiple section blocks
- keep each section within Slack's 3,000-character limit
- preserve line boundaries where possible
- handle long individual lines and Unicode safely
- truncate headers to Slack's 150-character limit with an ellipsis
- include Slack HTTP status and response details in publish errors

## Problem

Slack release notes were rendered into a single Block Kit section. Larger releases could exceed Slack's 3,000-character section limit, causing the incoming webhook to return HTTP 400, typically with `invalid_blocks`.

The existing error handling also hid Slack's response body, making the failure difficult to diagnose.

## Implementation

Newsletter content is now divided into multiple `section` blocks without dropping release-note details. Splitting prefers line boundaries and falls back to Unicode-safe character boundaries for oversized individual lines.

Oversized headers use 149 characters plus `…`, keeping them within Slack's 150-character limit while making truncation visible.

Slack publish failures now include available upstream details, for example:

`HTTP 400: invalid_blocks`

## Testing

Added coverage for:

- exactly 3,000 characters
- content exceeding 3,000 characters
- line-boundary splitting
- oversized individual lines
- Unicode-safe splitting
- header truncation with an ellipsis
- unchanged headers within the limit

All 138 tests pass.